### PR TITLE
Add MariaDB dependencies to Dockerfile and requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ RUN adduser -D -u ${PUID} ldap
 WORKDIR /home/ldap
 
 RUN apk add --no-cache postgresql-libs && \
+    apk add --no-cache mariadb-connector-c-dev && \
     apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev
+
 COPY requirements.txt .
 RUN python -m venv venv && \
     venv/bin/pip install --no-cache-dir gunicorn && \
@@ -15,6 +17,7 @@ RUN python -m venv venv && \
 FROM python:3.10-alpine
 
 RUN apk add --no-cache postgresql-libs
+Run apk add --no-cache mariadb-connector-c-dev
 
 ARG PUID=1000
 RUN adduser -D -u ${PUID} ldap

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 Mako==1.1.6
 MarkupSafe==2.0.1
+mysqlclient==2.1.1
 psycopg2==2.9.3
 PyJWT==2.3.0
 python-dotenv==0.19.2


### PR DESCRIPTION
Hi threadnought,
I just added a few lines to make the glauth-ui MySQL/MariaDB support available in the docker container. If you would like an example docker-compose file to proof that it's working let me know